### PR TITLE
User agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `mixed-content-scanner-cli` will be documented in this file
 
+
+## 1.2.1 - 2019-11-05
+
+- Add `--user-agent` option.
+
 ## 1.2.0 - 2018-03-22
 
 - Add `--ignore-robots` option.

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ mixed-content-scanner scan https://spatie.be --filter="^\/en" --ignore="opensour
 
 ### Ignoring robots
 
-By default, the crawler will respect robots data. You can ignore them though with the `--ignore-robots option`.
+By default, the crawler will respect robots data. You can ignore them though with the `--ignore-robots` option.
 
 ```bash
 mixed-content-scanner scan https://example.com --ignore-robots
 ```
 
 ### Custom User agent
-By default, the crawler uses the underlying guzzle client for the user agent. You can override this value with the `--user-agent option`.
+By default, the crawler uses the underlying guzzle client for the user agent. You can override this value with the `--user-agent` option.
 ```bash
 mixed-content-scanner scan https://example.com --user-agent='MyCustomCrawler'
 ```

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ By default, the crawler will respect robots data. You can ignore them though wit
 mixed-content-scanner scan https://example.com --ignore-robots
 ```
 
+### Custom User agent
+By default, the crawler uses '' as the user agent. You can override this value with the `--user-agent option`.
+```bash
+mixed-content-scanner scan https://example.com --user-agent='MyCustomCrawler'
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ mixed-content-scanner scan https://example.com --ignore-robots
 ```
 
 ### Custom User agent
-By default, the crawler uses '' as the user agent. You can override this value with the `--user-agent option`.
+By default, the crawler uses the underlying guzzle client for the user agent. You can override this value with the `--user-agent option`.
 ```bash
 mixed-content-scanner scan https://example.com --user-agent='MyCustomCrawler'
 ```

--- a/src/ScanCommand.php
+++ b/src/ScanCommand.php
@@ -4,13 +4,13 @@ namespace Spatie\MixedContentScannerCli;
 
 use GuzzleHttp\RequestOptions;
 use Spatie\Crawler\Crawler;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Console\Input\InputArgument;
 use Spatie\MixedContentScanner\MixedContentScanner;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ScanCommand extends Command
 {

--- a/src/ScanCommand.php
+++ b/src/ScanCommand.php
@@ -23,7 +23,8 @@ class ScanCommand extends Command
             ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'urls whose path pass the regex will be scanned')
             ->addOption('ignore', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'urls whose path pass the regex will not be scanned')
             ->addOption('ignore-robots', null, InputOption::VALUE_NONE, 'Ignore robots.txt, robots meta tags and -headers.')
-            ->addOption('verify-ssl', null, InputOption::VALUE_NONE, 'Verify the craweld urls have a valid certificate. If they do not an empty response will be the result of the crawl');
+            ->addOption('verify-ssl', null, InputOption::VALUE_NONE, 'Verify the craweld urls have a valid certificate. If they do not an empty response will be the result of the crawl')
+            ->addOption('user-agent', null, InputOption::VALUE_REQUIRED, 'User agent string to use for requests');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -43,11 +44,15 @@ class ScanCommand extends Command
         );
 
         $ignoreRobots = $input->getOption('ignore-robots');
+        $userAgent = $input->getOption('user-agent');
 
         (new MixedContentScanner($mixedContentLogger))
-            ->configureCrawler(function (Crawler $crawler) use ($ignoreRobots) {
+            ->configureCrawler(function (Crawler $crawler) use ($ignoreRobots, $userAgent) {
                 if ($ignoreRobots) {
                     $crawler->ignoreRobots();
+                }
+                if ($userAgent) {
+                    $crawler->setUserAgent($userAgent);
                 }
             })
             ->setCrawlProfile($crawlProfile)

--- a/tests/MixedContentScannerTest.php
+++ b/tests/MixedContentScannerTest.php
@@ -10,7 +10,7 @@ class MixedContentScannerTest extends TestCase
     use MatchesSnapshots;
 
     protected $logFile = __DIR__.'/temp/log.txt';
-    
+
     protected $userAgentLogFile = __DIR__.'/temp/agent.txt';
 
     public function setUp()

--- a/tests/MixedContentScannerTest.php
+++ b/tests/MixedContentScannerTest.php
@@ -59,6 +59,7 @@ class MixedContentScannerTest extends TestCase
     public function it_can_pass_a_custom_user_agent()
     {
         $userAgent = 'My-custom-user-agent-string';
+        
         $this->performScan('http://' . Server::getServerUrl('userAgent')." --user-agent={$userAgent}");
 
         $this->assertEquals(file_get_contents($this->userAgentLogFile), $userAgent);

--- a/tests/MixedContentScannerTest.php
+++ b/tests/MixedContentScannerTest.php
@@ -59,8 +59,8 @@ class MixedContentScannerTest extends TestCase
     public function it_can_pass_a_custom_user_agent()
     {
         $userAgent = 'My-custom-user-agent-string';
-        
-        $this->performScan('http://' . Server::getServerUrl('userAgent')." --user-agent={$userAgent}");
+
+        $this->performScan('http://'.Server::getServerUrl('userAgent')." --user-agent={$userAgent}");
 
         $this->assertEquals(file_get_contents($this->userAgentLogFile), $userAgent);
     }

--- a/tests/MixedContentScannerTest.php
+++ b/tests/MixedContentScannerTest.php
@@ -10,12 +10,14 @@ class MixedContentScannerTest extends TestCase
     use MatchesSnapshots;
 
     protected $logFile = __DIR__.'/temp/log.txt';
+    
+    protected $userAgentLogFile = __DIR__.'/temp/agent.txt';
 
     public function setUp()
     {
         Server::boot();
 
-        $this->createLogFile();
+        $this->createLogFiles();
     }
 
     /** @test */
@@ -53,18 +55,34 @@ class MixedContentScannerTest extends TestCase
         $this->assertMatchesSnapshot(file_get_contents($this->logFile));
     }
 
+    /** @test */
+    public function it_can_pass_a_custom_user_agent()
+    {
+        $userAgent = 'My-custom-user-agent-string';
+        $this->performScan('http://' . Server::getServerUrl('userAgent')." --user-agent={$userAgent}");
+
+        $this->assertEquals(file_get_contents($this->userAgentLogFile), $userAgent);
+    }
+
     protected function performScan(?string $arguments = '')
     {
         exec("./mixed-content-scanner scan {$arguments} > {$this->logFile}");
     }
 
-    protected function createLogFile()
+    protected function createLogFile($file)
     {
-        if (file_exists($this->logFile)) {
-            unlink($this->logFile);
+        if (file_exists($file)) {
+            unlink($file);
         }
 
-        touch($this->logFile);
+        touch($file);
+    }
+
+    protected function createLogFiles()
+    {
+        foreach ([$this->logFile, $this->userAgentLogFile] as $file) {
+            $this->createLogFile($file);
+        }
     }
 
     public function assertLogContains($expectedString)

--- a/tests/server/public/index.php
+++ b/tests/server/public/index.php
@@ -23,7 +23,7 @@ $app->get('/ignore', function () {
 });
 
 $app->get('/userAgent', function () {
-    file_put_contents( dirname(dirname(__DIR__)) . '/temp/agent.txt', $_SERVER['HTTP_USER_AGENT']);
+    file_put_contents( dirname(__DIR__, 2).'/temp/agent.txt', $_SERVER['HTTP_USER_AGENT']);
     return view('userAgent');
 });
 

--- a/tests/server/public/index.php
+++ b/tests/server/public/index.php
@@ -22,6 +22,11 @@ $app->get('/ignore', function () {
     return view('ignore');
 });
 
+$app->get('/userAgent', function () {
+    file_put_contents( dirname(dirname(__DIR__)) . '/temp/agent.txt', $_SERVER['HTTP_USER_AGENT']);
+    return view('userAgent');
+});
+
 $app->get('noResponse', function () {
     die();
 });

--- a/tests/server/public/index.php
+++ b/tests/server/public/index.php
@@ -24,6 +24,7 @@ $app->get('/ignore', function () {
 
 $app->get('/userAgent', function () {
     file_put_contents(dirname(__DIR__, 2).'/temp/agent.txt', $_SERVER['HTTP_USER_AGENT']);
+
     return view('userAgent');
 });
 

--- a/tests/server/public/index.php
+++ b/tests/server/public/index.php
@@ -23,7 +23,7 @@ $app->get('/ignore', function () {
 });
 
 $app->get('/userAgent', function () {
-    file_put_contents( dirname(__DIR__, 2).'/temp/agent.txt', $_SERVER['HTTP_USER_AGENT']);
+    file_put_contents(dirname(__DIR__, 2).'/temp/agent.txt', $_SERVER['HTTP_USER_AGENT']);
     return view('userAgent');
 });
 

--- a/tests/server/resources/views/userAgent.blade.php
+++ b/tests/server/resources/views/userAgent.blade.php
@@ -1,0 +1,1 @@
+<img src="/relative-image.jpg" />


### PR DESCRIPTION
I wanted to use this tool to scan for mixed content on our sites, but we use a third party bot defense to protect our sites from automated scraping, etc. I also cannot whitelist by IP as I will launch this AWS and the IP will change on each run.

I do not want to whitelist the generic guzzle header as that could be replicated by anyone with this tool and a similar php version.

Allowing a custom user agent means I can whitelist a unique string for use with this tool.